### PR TITLE
Snowflake privilege update - use temporary stage

### DIFF
--- a/export_snowflake/__init__.py
+++ b/export_snowflake/__init__.py
@@ -94,11 +94,11 @@ def direct_transfer_data_from_s3_to_snowflake(config, o, file_format_type):
         # generate a new stage with stream in Snowflake
         # the stage will be an external stage that points to the s3
         # the following merge query will be processed directly against the external stage
-        db_sync.generate_temporary_external_s3_stage(bucket, prefix, config['s3_credentials'])
+        stage_generation_query = db_sync.generate_temporary_external_s3_stage(bucket, prefix, config['s3_credentials'])
         
         # after creating the external stage, we could load the file directly from the s3 to Snowflake
         # need to specify the patterns in the s3 bucket to filter out the target csv.gz files
-        db_sync.load_file()
+        db_sync.load_file(stage_generation_query)
         
         transfer_end_time = time.time()
         stream = config["stream"]

--- a/export_snowflake/db_sync.py
+++ b/export_snowflake/db_sync.py
@@ -540,8 +540,6 @@ class DbSync:
             aws_session_token=s3_credentials.get('sessionToken', None),
             file_format_name=self.connection_config['file_format']
         )
-        
-        self.logger.debug('Temporary external stage generation query: %s', stage_generation_query)
                 
         # temporary stage will only exist during the connection cursor session
         # only execute the generation query later during the data loading session
@@ -580,6 +578,7 @@ class DbSync:
                 cur.execute(default_schema_query)
                 
                 # execute the temporary stage generation query
+                self.logger.debug('Temporary external stage generation query: %s', stage_generation_query)
                 cur.execute(stage_generation_query)
                 
                 self.logger.debug('Running query: %s', merge_sql)

--- a/export_snowflake/db_sync.py
+++ b/export_snowflake/db_sync.py
@@ -531,18 +531,17 @@ class DbSync:
         temp_stage_name = self.get_temporary_stage_name()
         destination_url = f"s3://{bucket}/{prefix}"
         
-        with self.open_connection() as connection:
-            with connection.cursor(snowflake.connector.DictCursor) as cur:
-                stage_generation_query = self.file_format.formatter.create_stage_generation_sql(
-                    stage_name=temp_stage_name,
-                    url=destination_url,
-                    aws_key_id=s3_credentials['accessKeyID'],
-                    aws_secret_key=s3_credentials['secretKey'],
-                    aws_session_token=s3_credentials.get('sessionToken', None),
-                    file_format_name=self.connection_config['file_format']
-                )
-                self.logger.debug('Creating temporary external stage: %s', stage_generation_query)
-                self.logger.debug(self.schema_name)
+
+        stage_generation_query = self.file_format.formatter.create_stage_generation_sql(
+            stage_name=temp_stage_name,
+            url=destination_url,
+            aws_key_id=s3_credentials['accessKeyID'],
+            aws_secret_key=s3_credentials['secretKey'],
+            aws_session_token=s3_credentials.get('sessionToken', None),
+            file_format_name=self.connection_config['file_format']
+        )
+        
+        self.logger.debug('Temporary external stage generation query: %s', stage_generation_query)
                 
         # temporary stage will only exist during the connection cursor session
         # only execute the generation query later during the data loading session

--- a/export_snowflake/db_sync.py
+++ b/export_snowflake/db_sync.py
@@ -544,11 +544,8 @@ class DbSync:
                 self.logger.debug('Creating temporary external stage: %s', stage_generation_query)
                 self.logger.debug(self.schema_name)
                 
-                # need to point to the correct schema before creating the stage
-                # default_schema_query = self.use_default_schema()
-                # cur.execute(default_schema_query)
-                
-                # cur.execute(stage_generation_query)
+        # temporary stage will only exist during the connection cursor session
+        # only execute the generation query later during the data loading session
         return stage_generation_query
 
     def remove_external_s3_stage(self):
@@ -584,7 +581,6 @@ class DbSync:
                 cur.execute(default_schema_query)
                 
                 # execute the temporary stage generation query
-                # temporary stage will exist during the connection cursor session
                 cur.execute(stage_generation_query)
                 
                 self.logger.debug('Running query: %s', merge_sql)

--- a/export_snowflake/file_formats/csv.py
+++ b/export_snowflake/file_formats/csv.py
@@ -51,7 +51,7 @@ def create_stage_generation_sql(stage_name: str,
                                 file_format_name: str) -> str:
     
     """Generate a CSV compatible snowflake CREATE STAGE command"""
-    return f"CREATE OR REPLACE STAGE {stage_name} " \
+    return f"CREATE OR REPLACE TEMPORARY STAGE {stage_name} " \
            f"URL = '{url}' " \
            f"CREDENTIALS=(" \
            f"AWS_KEY_ID='{aws_key_id}' " \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "export-snowflake"
-version="2.3.0.0"
+version="2.4.0"
 description = "Export for loading data from S3 to Snowflake"
 authors = ["Wise"]
 classifiers = [


### PR DESCRIPTION
JIRA: https://varicent.atlassian.net/browse/WP-22172

when client exports to an existing table or a new table to an existing schema, the former change requires extra privilege for `CREAT STAGE` compared to before.

This was because we create permanent external stage pointing to the s3 bucket, to bypass this, we can create a temporary stage instead. A temporary stage will only be alive during the connection session, so we have to generate the temp stage in the same connection cursor session as the data loading execution.