### PR TITLE
fix(WP-31288): map storage integration AssumeRole failures to snowflake.clientError

### DIFF
--- a/export_snowflake/db_sync.py
+++ b/export_snowflake/db_sync.py
@@ -17,6 +17,22 @@ from export_snowflake.exceptions import TooManyRecordsException, SymonException
 from export_snowflake.upload_clients.s3_upload_client import S3UploadClient
 from export_snowflake.upload_clients.snowflake_upload_client import SnowflakeUploadClient
 
+STORAGE_INTEGRATION_ASSUME_ROLE_ERROR_MESSAGE = (
+    'Snowflake could not assume the IAM role for this connection\'s storage integration. '
+    'Edit the Snowflake connection, run DESCRIBE INTEGRATION on your storage integration in Snowflake, '
+    'and update the Principal and External ID fields to match STORAGE_AWS_IAM_USER_ARN and '
+    'STORAGE_AWS_EXTERNAL_ID. Ensure STORAGE_AWS_ROLE_ARN in Snowflake matches the IAM role ARN '
+    'shown in the connection setup wizard.'
+)
+
+
+def raise_for_storage_integration_assume_role_error(err_msg: str) -> None:
+    """Map Snowflake storage-integration IAM AssumeRole failures to a client error."""
+    if 'Error assuming AWS_ROLE' in err_msg or (
+        'sts:AssumeRole' in err_msg and 'is not authorized to perform' in err_msg
+    ):
+        raise SymonException(STORAGE_INTEGRATION_ASSUME_ROLE_ERROR_MESSAGE, 'snowflake.clientError')
+
 
 def validate_config(config):
     """Validate configuration"""
@@ -629,8 +645,12 @@ class DbSync:
                 
                 # execute the temporary stage generation query
                 self.logger.debug('Temporary external stage generation query: %s', stage_generation_query)
-                cur.execute(stage_generation_query)
-                
+                try:
+                    cur.execute(stage_generation_query)
+                except snowflake.connector.errors.ProgrammingError as e:
+                    raise_for_storage_integration_assume_role_error(str(e))
+                    raise
+
                 self.logger.debug('Running query: %s', merge_sql)
                 try:
                     cur.execute(merge_sql)
@@ -644,7 +664,8 @@ class DbSync:
                     raise
                 except snowflake.connector.errors.ProgrammingError as e:
                     err_msg = str(e)
-                    if 'Insufficient privileges to operate on table' in str(e):
+                    raise_for_storage_integration_assume_role_error(err_msg)
+                    if 'Insufficient privileges to operate on table' in err_msg:
                         table_name = self.table_name(stream, False, True)
                         raise SymonException(f'INSERT/UPDATE privileges on table {table_name} are missing.', 'snowflake.clientError')
                     raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "export-snowflake"
-version="4.9.0"
+version="4.9.1"
 description = "Export for loading data from S3 to Snowflake"
 authors = ["Wise"]
 

--- a/tests/unit/test_db_sync.py
+++ b/tests/unit/test_db_sync.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch, call
 
 from export_snowflake import db_sync
-from export_snowflake.exceptions import PrimaryKeyNotFoundException
+from export_snowflake.exceptions import PrimaryKeyNotFoundException, SymonException
 
 
 class TestDBSync(unittest.TestCase):
@@ -639,3 +639,19 @@ class TestDBSync(unittest.TestCase):
         #     call(['alter table dummy-schema."TABLE1" add primary key("ID");',
         #           'alter table dummy-schema."TABLE1" alter column "ID" drop not null;'])
         # ])
+
+    def test_raise_for_storage_integration_assume_role_error_wp_31288(self):
+        assume_role_msg = (
+            '003167 (42601): Error assuming AWS_ROLE:\n'
+            'User: arn:aws:iam::486044735905:user/75pg-s-c1ss4835 is not authorized to perform: '
+            'sts:AssumeRole on resource: arn:aws:iam::541224180711:role/external/org/snowflake/storage-integration-a4'
+        )
+        with self.assertRaises(SymonException) as ctx:
+            db_sync.raise_for_storage_integration_assume_role_error(assume_role_msg)
+        self.assertEqual(ctx.exception.code, 'snowflake.clientError')
+        self.assertIn('storage integration', str(ctx.exception))
+
+        with self.assertRaises(SymonException):
+            db_sync.raise_for_storage_integration_assume_role_error('Error assuming AWS_ROLE: denied')
+
+        db_sync.raise_for_storage_integration_assume_role_error('some other programming error')


### PR DESCRIPTION
## Summary
Maps Snowflake storage integration IAM AssumeRole failures to `SymonException` with `snowflake.clientError` so symon-ai/app `ExportErrorParser.getErrorFromErrorInfo` surfaces an actionable 400 to the user.

## Related
- symon-ai/app PR WP-31288
- Jira WP-31288

Tagged `v4.9.1` for export-activity docker build.